### PR TITLE
Add fn currentUser: exposes clients current uid.

### DIFF
--- a/src/client/cloak.js
+++ b/src/client/cloak.js
@@ -192,6 +192,10 @@
         callbacks[name].push(callback);
       },
 
+      currentUser: function() {
+        return uid;
+      },
+
       message: function(name, arg) {
         if (this.connected()) {
           socket.emit('message-' + name, arg);

--- a/test/test.js
+++ b/test/test.js
@@ -1130,6 +1130,38 @@ module.exports = _.extend(suite, {
     });
     server.run();
     client.run(this.host);
+  },
+
+  currentUser: function(test) {
+    var server = this.server;
+    var client = suite.createClient();
+    var userId = undefined;
+
+    test.expect(1);
+
+    var room;
+
+    server.configure({
+      port: this.port,
+      messages: {
+        checkUser: function(arg, user) {
+          test.equals(user.id, userId);
+          test.done();
+        }
+      }
+    });
+
+    client.configure({
+      serverEvents: {
+        begin: function() {
+          userId = client.currentUser();
+          client.message('checkUser');
+        }
+      }
+    });
+
+    server.run();
+    client.run(this.host);
   }
 
 });


### PR DESCRIPTION
I think it'd be useful to have access to the clients current uid to check against server events (ex: which player are you in a list of members.) 
