### PR TITLE
Completely destroy instance state in `cloak.stop`

### DIFF
--- a/src/client/cloak.js
+++ b/src/client/cloak.js
@@ -3,6 +3,10 @@
 
 (function() {
 
+  var removeKey = function(val, key, obj) {
+    delete obj[key];
+  };
+
   var createCloak = function() {
 
     var uid;
@@ -21,21 +25,44 @@
         io = b;
       },
 
+      /**
+       * Set configuration options for Cloak. These options will be applied
+       * immediately if Cloak has already been started (see `cloak.run`), and
+       * they will be referenced in all future calls to `clock.run` until
+       * overwritten.
+       */
       configure: function(configArg) {
 
-        _(configArg).forEach(function(val, key) {
-          if (key === 'serverEvents') {
-            _(val).forEach(function(eventHandler, eventName) {
-              cloak._on('cloak-' + eventName, eventHandler);
-            });
-          }
-          else if (key === 'timerEvents') {
-            timerEvents = val;
-          }
-          else {
-            config[key] = val;
-          }
+        // When specified, the `messages` option should trigger the complete
+        // removal of any previously-bound message handlers.
+        if (socket && configArg.messages) {
+          _(config.messages).forEach(function(handler, name, messageHandlers) {
+            socket.removeListener('message-' + name);
+            cloak._off('message-' + name, handler);
+          });
+        }
+
+        _.extend(config, configArg);
+
+        if (socket) {
+          cloak._applyConfig(config);
+        }
+      },
+
+      _applyConfig: function(toApply) {
+
+        _(toApply.messages).forEach(function(handler, name) {
+          socket.on('message-' + name, function(data) {
+            cloak._trigger('message-' + name, data);
+          });
+          cloak._on('message-' + name, handler);
         });
+
+        _(toApply.serverEvents).forEach(function(eventHandler, eventName) {
+          cloak._on('cloak-' + eventName, eventHandler);
+        });
+
+        _.extend(timerEvents, toApply.timerEvents);
       },
 
       _on: function(event, handler) {
@@ -159,18 +186,16 @@
           }
         });
 
-        _(config.messages).forEach(function(handler, name) {
-          socket.on('message-' + name, function(data) {
-            cloak._trigger('message-' + name, data);
-          });
-          cloak._on('message-' + name, handler);
-        });
-
+        cloak._applyConfig(config);
       },
 
       stop: function() {
         this._disconnect();
         cloak._trigger('cloak-end');
+        socket.removeAllListeners();
+        _.forEach(events, removeKey);
+        _.forEach(timerEvents, removeKey);
+        socket = null;
       },
 
       _disconnect: function() {
@@ -182,7 +207,7 @@
       },
 
       connected: function() {
-        return socket.socket.connected;
+        return socket && socket.socket.connected;
       },
 
       _callback: function(name, callback) {


### PR DESCRIPTION
Cloak does not offer any recovery transition from the "stopped" state.
After invoking `cloak.stop`, clients must call `clock.run` before
continuing to interact with the library. In that case, the original
socket will be discarded and a new one created in its place.

Because of this, all state associated with the disconnected socket
should be removed in response to any `stop` operation.

Event handlers specified in calls to `cloack.configure` must be
partially applied--only newly-specified handlers should be re-bound (and
only if `clock.run` has been invoked). Care has been taken to preserve
existing behavior of Cloak:
- The `messages` option, when specified, completely removes any
  previously-bound `message` event handlers before binding the new
  handlers it describes.
- The `serverEvents` option, when specified, is merged into the
  collection of server event handlers.
