### PR TITLE
Switch .innerText DOM output to .textContent

### DIFF
--- a/examples/chat/client/app.js
+++ b/examples/chat/client/app.js
@@ -9,13 +9,13 @@ cloak.configure({
   messages: {
     chat: function(msg) {
       var message = document.createElement('div');
-      message.innerText = msg;
+      message.textContent = msg;
       message.className = 'msg';
       messages.appendChild(message);
       messages.scrollTop = messages.scrollHeight;
     },
     userCount: function(count) {
-      counter.innerText = count;
+      counter.textContent = count;
     }
   },
 });


### PR DESCRIPTION
.innerText started as an IE-ism, but .textContent is the WC3 standard. Eventually, IE9+ supported textContent, but Firefox stood firm (or "stubborn") on NOT supporting innerText. As stands, innerText will break this example for modern Firefox browsers, and I don't believe that punishing IE8 users is necessarily a bad thing. ;)

Mind, there's ways to normalize use of this property for maximum browser compat, but I believe the spirit of this example is to keep the code as lean as possible.
