### PR TITLE
user.connected() needs type-coerced equality

### DIFF
--- a/src/server/cloak/user.js
+++ b/src/server/cloak/user.js
@@ -37,7 +37,7 @@ module.exports = (function() {
     },
 
     connected: function() {
-      return this.disconnectedSince === null;
+      return this.disconnectedSince == null;
     },
 
     _userData: function() {


### PR DESCRIPTION
this.disconnectSince begins as undefined. The test for (undefined === null) will always produce false, since the typeof null is "object". As stands, user.connected() erroneously returns false for a connected user. Relaxing the test will return the expected result.
