### PR TITLE
On user.delete() immediately make disconnected

### DIFF
--- a/src/server/cloak/user.js
+++ b/src/server/cloak/user.js
@@ -48,6 +48,7 @@ module.exports = (function() {
     },
 
     delete: function() {
+      this.disconnectedSince = this.disconnectedSince || new Date().getTime();
       this.leaveRoom();
       this._socket.disconnect();
       this.cloak._deleteUser(this);


### PR DESCRIPTION
The strongest use case for user.connected() is in the memberLeaves handler for a room. Here, we're going to want to know if the user changed rooms or was actually disconnected, and act accordingly (e.g. save state). This would typically be differentiated via a call to user.delete().

Thus, setting the property that yields our .connected() result within user.delete() needs to happen before the call to this.leaveRoom(). As implemented, I allowed a previous (older) disconnect stamp to remain, in case .delete() is called from another cleanup function.

This seemed to be the simpler solution to serving a practical use. An alternative that could still be considered would be to support an onDisconnect handler for users, but there's no reason why both can't exist.
