### PR TITLE
Unset client ID when stopped

### DIFF
--- a/src/client/cloak.js
+++ b/src/client/cloak.js
@@ -210,6 +210,7 @@
         _.forEach(events, removeKey);
         _.forEach(timerEvents, removeKey);
         socket = null;
+        uid = undefined;
       },
 
       _disconnect: function() {

--- a/test/test.js
+++ b/test/test.js
@@ -278,7 +278,7 @@ module.exports = _.extend(suite, {
     var server = this.server;
     var client = suite.createClient();
     var host = this.host;
-    var pingCount = 0;
+    var secondRun = false;
 
     server.configure({
       port: this.port
@@ -288,6 +288,11 @@ module.exports = _.extend(suite, {
     client.configure({
       serverEvents: {
         begin: function() {
+          if (secondRun) {
+            server.messageAll('custom');
+            return;
+          }
+
           client.stop();
 
           client.configure({
@@ -297,10 +302,9 @@ module.exports = _.extend(suite, {
               }
             }
           });
+
+          secondRun = true;
           client.run(host);
-        },
-        resume: function() {
-          server.messageAll('custom');
         }
       }
     });


### PR DESCRIPTION
> When the client invokes `stop`, it is signalling an explicit intent to
> disconnect. Therefore, subsequent connections should not be considered
> 'resume' events, but complete 'begin' events in their own right.
> 
> By unsetting the client ID, multiple `run` invocations each behave
> identically (each sending a new 'begin' event to the server), and the
> 'resume' event is reserved for only unexpected re-connections.

The current behavior is causing an error in my application because we are also using [the "resource" conviguration for Socket.io](https://github.com/LearnBoost/Socket.IO/wiki/Configuring-Socket.IO) to differentiate connections. When the user switches between connections, [the "resume" event triggered by the server is labeled as "invalid"](https://github.com/incompl/cloak/blob/5ac8450ccbef47eeed8752967151f4b3e4bd7c9c/src/server/cloak/index.js#L141-L144).
